### PR TITLE
fix travis typo

### DIFF
--- a/{{cookiecutter.pypi_name}}/README.rst
+++ b/{{cookiecutter.pypi_name}}/README.rst
@@ -50,4 +50,4 @@ Package resources
 Travis-ci
 ---------
 
-After creating package on github, move to tracis-ci.org, and turn on ci builds for given package.
+After creating package on github, move to https://travis-ci.org/, and turn on ci builds for given package.


### PR DESCRIPTION
I've just changed `tracis` -> `travis` and made it a link. There are no more `tracis` misspellings.